### PR TITLE
Prevent error on systems with older cURL compile target

### DIFF
--- a/src/Threema/MsgApi/HttpDriver/CurlHttpDriver.php
+++ b/src/Threema/MsgApi/HttpDriver/CurlHttpDriver.php
@@ -168,7 +168,7 @@ class CurlHttpDriver implements HttpDriverInterface
         }
 
         $pinnedKey = $this->tlsOptions[self::tlsOptionPinnedKey];
-        if (!empty($pinnedKey)) {
+        if (defined('CURLOPT_PINNEDPUBLICKEY') && !empty($pinnedKey)) {
             $options[CURLOPT_PINNEDPUBLICKEY] = $pinnedKey;
         }
 


### PR DESCRIPTION
On systems, where the PHP cURL extension is compiled against an older version of cURL without support for public key pinning (e.g. the builds from https://rpms.remirepo.net/ for RHEL/CentOS 7), the CurlHttpDriver fails with a 500 error, stating that the constant CURLOPT_PINNEDPUBLICKEY is not found. For the worse this happens even when the PHP installation itself uses a newer cURL, but the extension doesn't know about that constant and its corresponding cURL option.

This PR adds a feature test to omit the certificate pinning on systems that don't support it (i.e. where the constant is not defined), otherwise the whole Threema-API cannot be used at all on those systems.